### PR TITLE
Add serper.dev search utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Serper.dev Caller
+
+Web application to run multiple searches against [serper.dev](https://serper.dev).
+
+Open `serper-dev-caller/index.html` in a browser, enter queries line by line and
+press **Start** to begin sending requests. Progress and responses appear on the
+page. Press **Stop** to abort processing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "bob-utils",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bob-utils",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "qunit": "^2.24.1"
+      }
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-watch": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.3.tgz",
+      "integrity": "sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qunit": {
+      "version": "2.24.1",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.24.1.tgz",
+      "integrity": "sha512-Eu0k/5JDjx0QnqxsE1WavnDNDgL1zgMZKsMw/AoAxnsl9p4RgyLODyo2N7abZY7CEAnvl5YUqFZdkImzbgXzSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "7.2.0",
+        "node-watch": "0.7.3",
+        "tiny-glob": "0.2.9"
+      },
+      "bin": {
+        "qunit": "bin/qunit.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "bob-utils",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "qunit"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "devDependencies": {
+    "qunit": "^2.24.1"
+  }
+}

--- a/serper-dev-caller/index.html
+++ b/serper-dev-caller/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Serper.dev Caller</title>
+  <style>
+    textarea { width: 100%; height: 150px; }
+    pre { background: #f0f0f0; padding: 10px; }
+  </style>
+</head>
+<body>
+  <h1>Serper.dev Caller</h1>
+  <textarea id="queries" placeholder="Enter queries, one per line"></textarea>
+  <br>
+  <button id="toggleButton" onclick="toggleStartStop()">Start</button>
+  <label id="statusLabel">0 / 0</label>
+  <br>
+  <progress id="progressBar" value="0" max="0" style="width:100%"></progress>
+  <pre><code id="output"></code></pre>
+
+  <script type="module" src="./script.js"></script>
+</body>
+</html>

--- a/serper-dev-caller/script.js
+++ b/serper-dev-caller/script.js
@@ -1,0 +1,68 @@
+import { parseQueries } from './utils.js';
+
+const API_KEY = '0c833bbdac7eb41ed54b9b786e375ab15492c440';
+let stopRequested = false;
+let isRunning = false;
+let queries = [];
+let currentIndex = 0;
+
+function updateStatus() {
+  const statusLabel = document.getElementById('statusLabel');
+  statusLabel.textContent = `${currentIndex} / ${queries.length}`;
+  const progressBar = document.getElementById('progressBar');
+  progressBar.max = queries.length;
+  progressBar.value = currentIndex;
+}
+
+export async function fetchQuery(query) {
+  const myHeaders = new Headers();
+  myHeaders.append('X-API-KEY', API_KEY);
+  myHeaders.append('Content-Type', 'application/json');
+  const raw = JSON.stringify({ q: query });
+  const requestOptions = {
+    method: 'POST',
+    headers: myHeaders,
+    body: raw,
+    redirect: 'follow'
+  };
+  const response = await fetch('https://google.serper.dev/maps', requestOptions);
+  return response.json();
+}
+
+async function processNext() {
+  if (!isRunning || stopRequested || currentIndex >= queries.length) {
+    isRunning = false;
+    document.getElementById('toggleButton').textContent = 'Start';
+    return;
+  }
+  const query = queries[currentIndex];
+  try {
+    const result = await fetchQuery(query);
+    const output = document.getElementById('output');
+    output.textContent += JSON.stringify(result).replace(/\n/g, '') + '\n';
+  } catch (err) {
+    const output = document.getElementById('output');
+    output.textContent += `Error for ${query}: ${err}\n`;
+  }
+  currentIndex++;
+  updateStatus();
+  setTimeout(processNext, 0);
+}
+
+export function toggleStartStop() {
+  if (isRunning) {
+    stopRequested = true;
+    return;
+  }
+  const text = document.getElementById('queries').value;
+  queries = parseQueries(text);
+  currentIndex = 0;
+  stopRequested = false;
+  isRunning = true;
+  document.getElementById('toggleButton').textContent = 'Stop';
+  document.getElementById('output').textContent = '';
+  updateStatus();
+  processNext();
+}
+
+window.toggleStartStop = toggleStartStop;

--- a/serper-dev-caller/utils.js
+++ b/serper-dev-caller/utils.js
@@ -1,0 +1,6 @@
+export function parseQueries(text) {
+  return text
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line.length > 0);
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,11 @@
+import { parseQueries } from '../serper-dev-caller/utils.js';
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+
+module('parseQueries');
+
+test('splits and trims lines', assert => {
+  const input = 'foo\nbar\n\nbaz ';
+  const expected = ['foo', 'bar', 'baz'];
+  assert.deepEqual(parseQueries(input), expected);
+});


### PR DESCRIPTION
## Summary
- implement web UI in `serper-dev-caller`
- call serper.dev for each query and show progress
- parse textarea content line by line
- add README usage notes
- configure QUnit and add tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685a5957c398832ba49bd6d0ec8dd4b4