### PR TITLE
Add browser-based test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ Web application to run multiple searches against [serper.dev](https://serper.dev
 Open `serper-dev-caller/index.html` in a browser, enter queries line by line and
 press **Start** to begin sending requests. Progress and responses appear on the
 page. Press **Stop** to abort processing.
+
+To run the unit tests without installing packages, open `test/index.html` in a web browser.

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>JavaScript documentation</title>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+        <!-- Bootstrap / JQuery / Knockout. -->
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous" />
+        <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js" integrity="sha384-+sLIOodYLS7CIrQpBjl+C7nPvqq+FbNUBDunl/OZv93DB7Ln/533i8e/mZXLi/P+" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.5.0/knockout-min.js"></script>
+
+        <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.24.1.css" />
+        <script src="https://code.jquery.com/qunit/qunit-2.24.1.js"></script>
+    </head>
+    <body class="container mt-3">
+        <h1>Unit Tests</h1>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+
+        <script type="module" src="./test-browser.js"></script>
+    </body>
+</html>

--- a/test/test-browser.js
+++ b/test/test-browser.js
@@ -1,0 +1,9 @@
+import { parseQueries } from '../serper-dev-caller/utils.js';
+
+QUnit.module('parseQueries');
+
+QUnit.test('splits and trims lines', assert => {
+  const input = 'foo\nbar\n\nbaz ';
+  const expected = ['foo', 'bar', 'baz'];
+  assert.deepEqual(parseQueries(input), expected);
+});


### PR DESCRIPTION
## Summary
- allow running tests directly in the browser
- document how to run them

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685a5bd57a14832ba9bc9bded724b902