### PR TITLE
Add caching to serper-dev caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ Web application to run multiple searches against [serper.dev](https://serper.dev
 Open `serper-dev-caller/index.html` in a browser, enter queries line by line and
 press **Start** to begin sending requests. Progress and responses appear on the
 page. Press **Stop** to abort processing.
+
+Duplicate queries are automatically cached so repeated lines are not sent to the
+remote API again. This reduces the number of requests made while still
+displaying results for every entered line.

--- a/serper-dev-caller/script.js
+++ b/serper-dev-caller/script.js
@@ -1,10 +1,11 @@
-import { parseQueries } from './utils.js';
+import { parseQueries, createCachedFetcher } from './utils.js';
 
 const API_KEY = '0c833bbdac7eb41ed54b9b786e375ab15492c440';
 let stopRequested = false;
 let isRunning = false;
 let queries = [];
 let currentIndex = 0;
+const fetchQueryCached = createCachedFetcher(fetchQuery);
 
 function updateStatus() {
   const statusLabel = document.getElementById('statusLabel');
@@ -37,7 +38,7 @@ async function processNext() {
   }
   const query = queries[currentIndex];
   try {
-    const result = await fetchQuery(query);
+    const result = await fetchQueryCached(query);
     const output = document.getElementById('output');
     output.textContent += JSON.stringify(result).replace(/\n/g, '') + '\n';
   } catch (err) {

--- a/serper-dev-caller/utils.js
+++ b/serper-dev-caller/utils.js
@@ -4,3 +4,15 @@ export function parseQueries(text) {
     .map(line => line.trim())
     .filter(line => line.length > 0);
 }
+
+export function createCachedFetcher(fetcher) {
+  const cache = new Map();
+  return async function(query) {
+    if (cache.has(query)) {
+      return cache.get(query);
+    }
+    const result = await fetcher(query);
+    cache.set(query, result);
+    return result;
+  };
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-import { parseQueries } from '../serper-dev-caller/utils.js';
+import { parseQueries, createCachedFetcher } from '../serper-dev-caller/utils.js';
 import QUnit from 'qunit';
 const { module, test } = QUnit;
 
@@ -8,4 +8,22 @@ test('splits and trims lines', assert => {
   const input = 'foo\nbar\n\nbaz ';
   const expected = ['foo', 'bar', 'baz'];
   assert.deepEqual(parseQueries(input), expected);
+});
+
+module('createCachedFetcher');
+
+test('returns cached result on second call', async assert => {
+  let count = 0;
+  const fetcher = async q => {
+    count++;
+    return q + '-result';
+  };
+  const cached = createCachedFetcher(fetcher);
+
+  const r1 = await cached('a');
+  const r2 = await cached('a');
+
+  assert.equal(count, 1, 'fetcher called once');
+  assert.equal(r1, 'a-result', 'first result matches');
+  assert.equal(r2, 'a-result', 'second result matches cached value');
 });


### PR DESCRIPTION
## Summary
- cache duplicate search queries so they are only sent once
- expose a `createCachedFetcher` helper and test it
- describe caching behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685a6030c060832ba4e2533502782f3a