### PR TITLE
Fix syntax errors in browser

### DIFF
--- a/fix-invalid-google-ids/utils.js
+++ b/fix-invalid-google-ids/utils.js
@@ -1,4 +1,4 @@
-export function parseTabText(text) {
+function parseTabText(text) {
   const lines = text.trim().split(/\r?\n/).filter(l => l.trim().length > 0);
   if (lines.length === 0) return [];
   const header = lines[0].split('\t');
@@ -17,7 +17,7 @@ export function parseTabText(text) {
   return records;
 }
 
-export function validateRecords(records) {
+function validateRecords(records) {
   const groups = new Map();
   for (const rec of records) {
     if (!groups.has(rec.SEARCH_QUERY)) groups.set(rec.SEARCH_QUERY, []);

--- a/serper-dev-caller/script.js
+++ b/serper-dev-caller/script.js
@@ -18,7 +18,7 @@ function updateStatus() {
   progressBar.setAttribute('aria-valuemax', queries.length);
 }
 
-export async function fetchQuery(query) {
+async function fetchQuery(query) {
   const myHeaders = new Headers();
   myHeaders.append('X-API-KEY', getApiKey());
   myHeaders.append('Content-Type', 'application/json');
@@ -53,7 +53,7 @@ async function processNext() {
   setTimeout(processNext, 0);
 }
 
-export function toggleStartStop() {
+function toggleStartStop() {
   if (isRunning) {
     stopRequested = true;
     return;
@@ -69,12 +69,12 @@ export function toggleStartStop() {
   processNext();
 }
 
-export function copyOutput() {
+function copyOutput() {
   const text = document.getElementById('output').textContent;
   navigator.clipboard.writeText(text);
 }
 
-export function cleanQueries() {
+function cleanQueries() {
   document.getElementById('queries').value = '';
 }
 

--- a/serper-dev-caller/utils.js
+++ b/serper-dev-caller/utils.js
@@ -1,11 +1,11 @@
-export function parseQueries(text) {
+function parseQueries(text) {
   return text
     .split(/\r?\n/)
     .map(line => line.trim())
     .filter(line => line.length > 0);
 }
 
-export function createCachedFetcher(fetcher) {
+function createCachedFetcher(fetcher) {
   const cache = new Map();
   return async function(query) {
     if (cache.has(query)) {


### PR DESCRIPTION
## Summary
- remove `export` keywords from utility functions
- update serper caller JS so functions attach globally

## Testing
- `npm test` *(fails: qunit not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a76e8a7ec832bb63b280cc8d27d0f