### PR TITLE
Add copy IS_VALID button

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,8 @@ To run the unit tests without installing packages, open `test/index.html` in a w
 Duplicate queries are automatically cached so repeated lines are not sent to the
 remote API again. This reduces the number of requests made while still
 displaying results for every entered line.
-\nNew webapp fix-invalid-google-ids added.
+## Fix Invalid Google IDs
+
+This helper webpage parses tab separated records and validates them against
+Google Places JSON. After validation you can copy all values of the `IS_VALID`
+column with the **Copy IS_VALID field** button to use in other tools.

--- a/fix-invalid-google-ids/index.html
+++ b/fix-invalid-google-ids/index.html
@@ -20,6 +20,7 @@
         <div class="form-group">
             <button class="btn btn-primary" data-bind="click: parse">Parse</button>
             <button class="btn btn-secondary ml-2" data-bind="click: validate">Validate</button>
+            <button class="btn btn-info ml-2" data-bind="click: copyIsValid">Copy IS_VALID field</button>
         </div>
         <table class="table table-bordered" data-bind="visible: records().length > 0">
             <thead>

--- a/fix-invalid-google-ids/script.js
+++ b/fix-invalid-google-ids/script.js
@@ -12,6 +12,11 @@ function AppViewModel() {
   this.validate = () => {
     validateRecords(this.records());
   };
+
+  this.copyIsValid = () => {
+    const text = collectIsValid(this.records());
+    navigator.clipboard.writeText(text);
+  };
 }
 
 ko.applyBindings(new AppViewModel());

--- a/fix-invalid-google-ids/utils.js
+++ b/fix-invalid-google-ids/utils.js
@@ -86,7 +86,12 @@ function getIsValid(rec) {
   return typeof rec.IS_VALID === 'function' ? rec.IS_VALID() : rec.IS_VALID;
 }
 
+function collectIsValid(records) {
+  return records.map(r => getIsValid(r)).join('\n');
+}
+
 if (typeof window !== 'undefined') {
   window.parseTabText = parseTabText;
   window.validateRecords = validateRecords;
+  window.collectIsValid = collectIsValid;
 }

--- a/test/test-browser.js
+++ b/test/test-browser.js
@@ -28,3 +28,14 @@ QUnit.test('marks matching name as valid', assert => {
   assert.equal(recs[1].IS_VALID(), '0');
 });
 
+QUnit.module('collectIsValid');
+QUnit.test('joins values with new lines', assert => {
+  const recs = [
+    { IS_VALID: ko.observable('1') },
+    { IS_VALID: ko.observable('0') },
+    { IS_VALID: ko.observable('2') }
+  ];
+  const result = collectIsValid(recs);
+  assert.equal(result, '1\n0\n2');
+});
+


### PR DESCRIPTION
## Summary
- update README with section about Fix Invalid Google IDs tool
- add Collect IS_VALID feature and expose via utils
- implement button and viewmodel action for copying values
- test Collect IS_VALID helper with qunit

## Testing
- `npm test` *(fails: qunit not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a7c8bd4d4832b8cebd08da23a83ef