### PR TITLE
Fix invalid group clearing

### DIFF
--- a/fix-invalid-google-ids/utils.js
+++ b/fix-invalid-google-ids/utils.js
@@ -70,6 +70,11 @@ function validateRecords(records) {
     group.forEach(r => {
       if (!getIsValid(r)) setIsValid(r, '0');
     });
+
+    const allZero = group.every(r => getIsValid(r) === '0');
+    if (allZero) {
+      group.forEach(r => setIsValid(r, ''));
+    }
   }
   return records;
 }

--- a/test/test-browser.js
+++ b/test/test-browser.js
@@ -28,6 +28,16 @@ QUnit.test('marks matching name as valid', assert => {
   assert.equal(recs[1].IS_VALID(), '0');
 });
 
+QUnit.test('clears values when all are invalid', assert => {
+  const recs = [
+    {ID:'1', GOOGLE_PLACE_ID:'a', NAME:'Foo', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID: ko.observable(''), SEARCH_QUERY:'w', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[]}'},
+    {ID:'2', GOOGLE_PLACE_ID:'b', NAME:'Bar', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID: ko.observable(''), SEARCH_QUERY:'w', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[]}'}
+  ];
+  validateRecords(recs);
+  assert.equal(recs[0].IS_VALID(), '');
+  assert.equal(recs[1].IS_VALID(), '');
+});
+
 QUnit.module('collectIsValid');
 QUnit.test('joins values with new lines', assert => {
   const recs = [

--- a/test/test.js
+++ b/test/test.js
@@ -51,3 +51,13 @@ test('marks matching name as valid', assert => {
   assert.equal(recs[1].IS_VALID, '0');
 });
 
+test('clears values when all are invalid', assert => {
+  const recs = [
+    {ID:'1', GOOGLE_PLACE_ID:'a', NAME:'Foo', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID:'', SEARCH_QUERY:'w', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[]}'},
+    {ID:'2', GOOGLE_PLACE_ID:'b', NAME:'Bar', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID:'', SEARCH_QUERY:'w', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[]}'}
+  ];
+  validateRecords(recs);
+  assert.equal(recs[0].IS_VALID, '');
+  assert.equal(recs[1].IS_VALID, '');
+});
+


### PR DESCRIPTION
## Summary
- update validation logic to clear `IS_VALID` values when all records in a search query remain invalid
- add test cases for the new behaviour

## Testing
- `npm test` *(fails: Failed to load file test/test.js)*

------
https://chatgpt.com/codex/tasks/task_b_685a80e825d8832b8e9b8af2f07ec6c7